### PR TITLE
Add completions for fish shell

### DIFF
--- a/completions/bcd.fish
+++ b/completions/bcd.fish
@@ -1,0 +1,5 @@
+# Have the `bcd` command inherit completions from `bookmark-cd`
+#
+# This needs to be in a seperate file in order to be automatically loaded
+
+complete -c bcd --wraps bookmark-cd

--- a/completions/bookmark-cd.fish
+++ b/completions/bookmark-cd.fish
@@ -1,0 +1,20 @@
+# Hand-written completions for the fish shell
+#
+# NOTE: Prefer builtin functions to external commands,
+# they are usally an order maginitude faster
+
+# Command substitution to list bookmarks
+set --local docomplete_bookmarks '$(string join \n $(string replace , \t < ~/.bcd)[2..])'
+
+# Disable file completions for entire command
+complete -c bookmark-cd -f
+
+complete -c bookmark-cd -d "Bookmarked directory to change to" -a "$docomplete_bookmarks"
+
+# TODO: Should we hint for bookmarks when specifying incompatible flag like --store
+complete -c bookmark-cd -s s -l store -d "Store the current directory as a bookmark" -r
+complete -c bookmark-cd -s r -l remote -d "Remove a specified bookmark" -ra "$docomplete_bookmarks"
+complete -c bookmark-cd -s l -l list -d 'List the stored bookmarks'
+complete -c bookmark-cd -s V -l version -d 'Print version information'
+complete -c bookmark-cd -s h -l help -d 'Print help'
+


### PR DESCRIPTION
These are not automatically installed.
I'm not sure how you want to do that.

Normally you would put it in the third-party vendor completions directory `~/.local/share/fish/vendor_completions.d` (affected by the `XDG_DATA_HOME` environment variable).
This is one of the [automatically loaded directories](https://fishshell.com/docs/current/completions.html#where-to-put-completions).

There need to be seperate completion files for `bcd` and `bookmark-cd` in order for auto-loading to work.

**EDIT**: This partially fixes #70 
