### PR TITLE
Lock home to 0.5.9

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,7 @@ name = "bookmark-cd"
 [dependencies]
 clap = { version = "=4.5.27", features = ["derive"] }
 csv = "=1.3.1"
-home = "=0.5.11"
+home = "=0.5.9"
 tabled = "0.17.0"
 pshell = "1.0.12"
 snapcraft = "0.4.0"


### PR DESCRIPTION
0.5.11 has a `rust-version` that is too close to the latest and preventing some users from `cargo install`ing this version.
I approved a working dependabot update for the last version without thinking things through.
